### PR TITLE
fix: replace bare except with Exception in tokenizer encoding

### DIFF
--- a/finetune/src/data.py
+++ b/finetune/src/data.py
@@ -408,7 +408,7 @@ def get_im_end_token_id(tokenizer: PreTrainedTokenizer) -> int:
         tokens = tokenizer.encode("<|im_end|>", add_special_tokens=False)
         if tokens:
             return tokens[0]
-    except:
+    except Exception:
         pass
     
     if hasattr(tokenizer, 'added_tokens_encoder'):


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` in `finetune/src/data.py` for the im_end token encoding fallback.